### PR TITLE
Feat/liquidation invariants

### DIFF
--- a/docs/invariants.md
+++ b/docs/invariants.md
@@ -44,11 +44,11 @@
 ## Liquidation
 
 - a liquidation should always make the position more safe
+- position health after liquidation is smaller or equal to target health factor or fully liquidated
 - liquidator should never pay more than `repayAmount`
 - credit paid should never be larger than `debt` / `liquidationPenalty`
 - `accruedBadDebt` should never exceed the sum of `debt` of liquidated positions
 - `position.collateral` should be zero if `position.normalDebt` is zero for a liquidated position
-- delta debt should only be bigger than `repayAmount` after a liquidation
 - delta debt should be equal to credit paid * `liquidationPenalty`
 
 ## Exchange / Redemptions

--- a/src/CDPVault.sol
+++ b/src/CDPVault.sol
@@ -11,7 +11,7 @@ import {ICDPVaultBase} from "./interfaces/ICDPVault.sol";
 import {IOracle} from "./interfaces/IOracle.sol";
 import {ICDPVault_TypeA_Factory} from "./interfaces/ICDPVault_TypeA_Factory.sol";
 
-import {WAD, toInt256, toUint64, max, min, add, sub, wmul, wdiv} from "./utils/Math.sol";
+import {WAD, toInt256, toUint64, max, min, add, sub, wmul, wdiv, wmulUp} from "./utils/Math.sol";
 import {DoubleLinkedList} from "./utils/DoubleLinkedList.sol";
 import {Permission} from "./utils/Permission.sol";
 import {Pause} from "./utils/Pause.sol";
@@ -1188,6 +1188,7 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
         uint256 settlementRate;
         uint256 settlementPenalty;
         uint256 maxCreditToExchange;
+        uint256 accruedBadDebt;
     }
 
     /// @notice Returns the position's interest rate state with the updated accrued rebate amount
@@ -1202,7 +1203,7 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
     /// @notice Executes an exchange of credit and collateral by settling position debt
     function _settleDebtAndReleaseCollateral(
         ExchangeCache memory cache, Position memory position, PositionIRS memory positionIRS, address owner
-    ) internal returns (ExchangeCache memory, Position memory) {
+    ) internal returns (ExchangeCache memory) {
         // limit the amount of credit to exchange by position debt to be settled
         uint256 creditToExchange;
         uint256 collateralToExchange;
@@ -1220,8 +1221,9 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
                 // then limit the amount of debt that can be settled such that at least the debt floor amount is left
                 (debt > maxDebtToSettle && debt - maxDebtToSettle < cache.debtFloor)
                     ? wdiv(debt - cache.debtFloor, cache.settlementPenalty) : wdiv(debt, cache.settlementPenalty),
-                wmul(position.collateral, cache.settlementRate)
+                wmulUp(position.collateral, cache.settlementRate)
         );
+
         // min(credit left to exchange, max credit to exchange)
         creditToExchange = min(cache.maxCreditToExchange, maxDebtToSettle);
 
@@ -1232,6 +1234,16 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
 
         // calculate the amount of collateral to exchange
         collateralToExchange = wdiv(creditToExchange, cache.settlementRate);
+        
+        // repay the position's debt balance and release the bought collateral amount
+        if (
+            collateralToExchange >= position.collateral && 
+            position.normalDebt > deltaNormalDebt
+        ){
+            collateralToExchange = position.collateral;
+            cache.accruedBadDebt += debt - deltaDebt;
+            deltaNormalDebt = position.normalDebt;
+        }
         }
 
         // reorder stack
@@ -1251,7 +1263,7 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
         );
 
         // repay the position's debt balance and release the bought collateral amount
-        position = _modifyPosition(
+        _modifyPosition(
             owner,
             position,
             positionIRS,
@@ -1266,7 +1278,7 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
         cache.creditExchanged += creditToExchange;
         cache.accruedInterest += accruedInterest;
 
-        return (cache, position);
+        return cache;
     }
 
     /// @notice Exchange credit for collateral
@@ -1324,7 +1336,7 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
                 spotPrice_,
                 vaultConfig_.liquidationRatio
             )) {
-                (cache,) = _settleDebtAndReleaseCollateral(cache, position, positionIRS, owner);
+                cache = _settleDebtAndReleaseCollateral(cache, position, positionIRS, owner);
             }
 
             limitOrderId = nextLimitOrderId;

--- a/src/CDPVault.sol
+++ b/src/CDPVault.sol
@@ -1234,8 +1234,8 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
 
         // calculate the amount of collateral to exchange
         collateralToExchange = wdiv(creditToExchange, cache.settlementRate);
-        
-        // repay the position's debt balance and release the bought collateral amount
+
+        // bound the amount of collateral to exchange and account for accrued bad debt (if any)        
         if (
             collateralToExchange >= position.collateral && 
             position.normalDebt > deltaNormalDebt

--- a/src/CDPVault.sol
+++ b/src/CDPVault.sol
@@ -1232,15 +1232,15 @@ abstract contract CDPVault is AccessControl, Pause, Permission, InterestRateMode
         (claimedRebate, positionIRS.accruedRebate) = _calculateRebateClaim(deltaDebt, debt, positionIRS.accruedRebate);
         deltaNormalDebt = calculateNormalDebt(deltaDebt, positionIRS.snapshotRateAccumulator, claimedRebate);
 
-        // calculate the amount of collateral to exchange
+        // calculate and bound the amount of collateral to exchange
         collateralToExchange = wdiv(creditToExchange, cache.settlementRate);
+        if (collateralToExchange > position.collateral) collateralToExchange = position.collateral;
 
-        // bound the amount of collateral to exchange and account for accrued bad debt (if any)        
+        // account for accrued bad debt (if any)        
         if (
-            collateralToExchange >= position.collateral && 
+            collateralToExchange == position.collateral && 
             position.normalDebt > deltaNormalDebt
         ){
-            collateralToExchange = position.collateral;
             cache.accruedBadDebt += debt - deltaDebt;
             deltaNormalDebt = position.normalDebt;
         }

--- a/src/test/invariant/Liquidate.invariant.t.sol
+++ b/src/test/invariant/Liquidate.invariant.t.sol
@@ -35,17 +35,12 @@ contract LiquidateInvariantTest is InvariantTestBase {
             limitOrderFloor: 1 ether,
             protocolFee: 0.01 ether
         });
+        vault.grantRole(TICK_MANAGER_ROLE, address(liquidateHandler));
 
         CDPVault_TypeA.GlobalIRS memory globalIRS = vault.getGlobalIRS();
         assertEq(globalIRS.baseRate, int64(BASE_RATE_1_005));
-
         liquidateHandler = new LiquidateHandler(vault, this, new GhostVariableStorage(), liquidationRatio, targetHealthFactor);
-
         _setupVaults();
-
-
-        // prepare price ticks
-        vault.grantRole(TICK_MANAGER_ROLE, address(liquidateHandler));
 
         excludeSender(address(vault));
         excludeSender(address(liquidateHandler));

--- a/src/test/invariant/handlers/BaseHandler.sol
+++ b/src/test/invariant/handlers/BaseHandler.sol
@@ -15,11 +15,15 @@ string constant VAULTS_CATEGORY = "VAULTS_CATEGORY";
 string constant CONTRACTS_CATEGORY = "CONTRACTS_CATEGORY";
 string constant LIMIT_ORDERS_CATEGORY = "LIMIT_ORDERS_CATEGORY";
 
-bytes32 constant TRACK_FUNCTION_START_KEY = keccak256("START");
-bytes32 constant TRACK_FUNCTION_END_KEY = keccak256("END");
+string constant TRACK_FUNCTION_START_KEY = "START";
+string constant TRACK_FUNCTION_END_KEY = "END";
 
-bytes32 constant RATE_ACCUMULATOR =  keccak256("rateAccumulator");
-bytes32 constant SNAPSHOT_RATE_ACCUMULATOR = keccak256("snapshotRateAccumulator");
+string constant RATE_ACCUMULATOR =  "rateAccumulator";
+string constant SNAPSHOT_RATE_ACCUMULATOR = "snapshotRateAccumulator";
+
+function getValueKey(address user, string memory key) pure returns (bytes32) {
+    return keccak256(abi.encode(user, key));
+}
 
 /// @title GhostVariableStorage
 /// @notice Ghost variable storage contract that tracks actors by category.
@@ -212,12 +216,20 @@ abstract contract BaseHandler is  CommonBase, StdCheats, StdUtils {
         setGhostValue(currentValueKey, value);
     }
 
+    function trackValue(string memory key, bytes32 value) internal {
+        trackValue(keccak256(abi.encode(key)), value);
+    }
+
     // Retrieve the current and the previous value of a tracked property
     function getTrackedValue(bytes32 key) public view returns (bytes32 prevValue, bytes32 currentValue){
         bytes32 prevValueKey = keccak256(abi.encode(key, "PREV"));
         bytes32 currentValueKey = keccak256(abi.encode(key));
         prevValue = getGhostValue(prevValueKey);
         currentValue = getGhostValue(currentValueKey);
+    }
+
+    function getTrackedValue(string memory key) public view returns (bytes32 prevValue, bytes32 currentValue){
+        return getTrackedValue(keccak256(abi.encode(key)));
     }
 
     // Track actors by category

--- a/src/test/invariant/handlers/BorrowHandler.sol
+++ b/src/test/invariant/handlers/BorrowHandler.sol
@@ -273,13 +273,19 @@ contract BorrowHandler is BaseHandler {
     }
 
     function getRateAccumulator() view public returns (uint64) {
-        bytes32 currentValueKey = keccak256("rateAccumulator");
-        return uint64(uint256(getGhostValue(currentValueKey)));
+        return uint64(uint256(
+            getGhostValue(
+                keccak256(abi.encode(RATE_ACCUMULATOR))
+            )
+        ));
     }
 
     function getSnapshotRateAccumulator(address position) view public returns (uint64) {
-        bytes32 currentValueKey = keccak256(abi.encodePacked(position, "snapshotRateAccumulator"));
-        return uint64(uint256(getGhostValue(currentValueKey)));
+        return uint64(uint256(
+            getGhostValue(
+                getValueKey(position, SNAPSHOT_RATE_ACCUMULATOR)
+            )
+        ));
     }
 
     function getPreviousRateAccumulator() view public returns (uint64) {
@@ -300,7 +306,7 @@ contract BorrowHandler is BaseHandler {
 
     function _trackSnapshotRateAccumulator(address position) private {
         InterestRateModel.PositionIRS memory positionIRS = vault.getPositionIRS(position);
-        trackValue(keccak256(abi.encode(SNAPSHOT_RATE_ACCUMULATOR, position)), bytes32(uint256(positionIRS.snapshotRateAccumulator)));
+        trackValue(getValueKey(position, SNAPSHOT_RATE_ACCUMULATOR), bytes32(uint256(positionIRS.snapshotRateAccumulator)));
     }
 
     // Generate the tick price for a limit order based on the seed

--- a/src/test/invariant/handlers/LiquidateHandler.sol
+++ b/src/test/invariant/handlers/LiquidateHandler.sol
@@ -4,33 +4,47 @@ pragma solidity ^0.8.19;
 import {IERC20} from "openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 import {InvariantTestBase} from "../InvariantTestBase.sol";
-import {BaseHandler, GhostVariableStorage} from "./BaseHandler.sol";
+import {BaseHandler, GhostVariableStorage, USERS_CATEGORY} from "./BaseHandler.sol";
 
 import {ICDPVaultBase} from "../../../interfaces/ICDPVault.sol";
 
-import {CDM} from "../../../CDM.sol";
+import {calculateDebt} from "../../../CDPVault.sol";
+import {CDM, getDebt} from "../../../CDM.sol";
 import {CDPVault_TypeAWrapper} from "../CDPVault_TypeAWrapper.sol";
-import {WAD, wdiv} from "../../../utils/Math.sol";
+import {WAD, min, wdiv, wmul, mul} from "../../../utils/Math.sol";
 
 contract LiquidateHandler is BaseHandler {
-    uint256 internal constant COLLATERAL_PER_POSITION = 1_000 ether;
+    uint256 internal constant COLLATERAL_PER_POSITION = 1_000_000 ether;
     
-    uint256 public immutable creditReserve = 100_000_000_000 ether;
-    uint256 public immutable collateralReserve = 100_000_000_000 ether;
+    uint256 public immutable creditReserve = 100_000_000_000_000 ether;
+    uint256 public immutable collateralReserve = 100_000_000_000_000 ether;
     
     uint256 public immutable maxCreateUserAmount = 10;
+    uint256 public immutable minLiquidateUserAmount = 1;
 
-    uint256 public immutable maxHealthFactor = 2 ether;
+    uint256 public immutable maxCollateralRatio = 2 ether;
+
+    address[] public liquidatedPositions;
+    uint256 public preLiquidationDebt;
+    uint256 public postLiquidationDebt;
+    uint256 public creditPaid;
+    uint256 public accruedBadDebt;
 
     CDM public cdm;
     CDPVault_TypeAWrapper public vault;
     IERC20 public token;
+    address public buffer;
 
-    uint64 internal liquidationRatio;
-    uint64 internal targetHealthFactor;
+    uint64 internal immutable liquidationRatio;
+    uint64 internal immutable targetHealthFactor;
+    uint256 internal immutable liquidationDiscount;
 
-    function liquidationPrice(ICDPVaultBase vault_) internal returns (uint256) {
-        return wdiv(vault_.spotPrice(), uint256(liquidationRatio));
+    function liquidationPrice(uint256 collateral, uint256 normalDebt) internal view returns (uint256 spotPrice) {
+        spotPrice = wmul(wdiv(wmul(normalDebt, uint256(liquidationRatio)), collateral), uint256(0.9 ether));
+    }
+
+    function liquidatedPositionsCount() public view returns (uint256) {
+        return liquidatedPositions.length;
     }
 
     constructor(
@@ -42,102 +56,234 @@ contract LiquidateHandler is BaseHandler {
     ) BaseHandler ("LiquidateHandler", testContract_, ghostStorage_) {
         vault = vault_;
         cdm = CDM(address(vault_.cdm()));
+        buffer = address(vault_.buffer());
         token = vault.token();
         liquidationRatio = positionLiquidationRatio_;
         targetHealthFactor = targetHealthFactor_;
+        ( ,liquidationDiscount, ) = vault.liquidationConfig(); 
     }
 
     function getTargetSelectors() public pure virtual override returns (bytes4[] memory selectors, string[] memory names) {
         selectors = new bytes4[](3);
         names = new string[](3);
-        selectors[0] = this.createPosition.selector;
-        names[0] = "createPosition";
+        selectors[0] = this.createPositions.selector;
+        names[0] = "createPositions";
 
         selectors[1] = this.liquidateRandom.selector;
         names[1] = "liquidateRandom";
 
-        selectors[2] = this.liquidateAll.selector;
-        names[2] = "liquidateAll";
+        selectors[2] = this.liquidateMultiple.selector;
+        names[2] = "liquidateMultiple";
     }
 
-    function createPosition(uint256 healthFactor) public useCurrentTimestamp onlyNonActor("users", msg.sender) {
+    function createPositions(uint256 seed, uint256 healthFactorSeed) public useCurrentTimestamp {
         trackCallStart(msg.sig);
 
-        // register sender as a user
-        address user = msg.sender;
-        addActor("users", msg.sender);
+        // reset state 
+        delete liquidatedPositions;
+        preLiquidationDebt = 0;
+        postLiquidationDebt = 0;
+        creditPaid = 0;
+        accruedBadDebt = 0;
 
-        // bound the health factor and calculate collateral and debt
-        healthFactor = bound(healthFactor, liquidationRatio, maxHealthFactor);
-        uint256 collateral = COLLATERAL_PER_POSITION;
-        uint256 debt = wdiv(collateral, healthFactor);
-        vault.modifyPermission(user, true);
+        for (uint256 i = 0; i < maxCreateUserAmount; i++) {
+            address user = address(uint160(uint256(keccak256(abi.encode(msg.sender, seed, i)))));
+            addActor(USERS_CATEGORY, user);
 
-        // create the position
-        vm.prank(user);
-        vault.modifyCollateralAndDebt({
-            owner:user, 
-            collateralizer: address(this), 
-            creditor: msg.sender, 
-            deltaCollateral: int256(collateral),
-            deltaNormalDebt: int256(debt)
-        });
+            // bound the health factor and calculate collateral and debt, randomize the health factor seed
+            uint256 minCollateralRatio = liquidationRatio;
+            uint256 collateralRatio = bound(uint256(keccak256(abi.encode(healthFactorSeed, user))), minCollateralRatio, maxCollateralRatio);
+            uint256 collateral = COLLATERAL_PER_POSITION;
+            uint256 debt = wdiv(collateral, collateralRatio);
+            vault.modifyPermission(user, true);
+
+            // create the position
+            vm.prank(user);
+            vault.modifyCollateralAndDebt({
+                owner:user, 
+                collateralizer: address(this), 
+                creditor: user, 
+                deltaCollateral: int256(collateral),
+                deltaNormalDebt: int256(debt)
+            });
+        }
 
         trackCallEnd(msg.sig);
     }
 
-    function liquidateRandom(uint256 randomSeed, uint256 liquidationHealthFactor, bool fullLiquidation) public useCurrentTimestamp {
+    function liquidateRandom(uint256 randomSeed) public useCurrentTimestamp {
         trackCallStart(msg.sig);
 
-        address user = getRandomActor("users", randomSeed);
+        address user = getRandomActor(USERS_CATEGORY, randomSeed);
         if(user == address(0)) return;
 
-        liquidationHealthFactor = bound(liquidationHealthFactor, 0, liquidationRatio-1);
-        uint256 newSpotPrice = liquidationPrice(vault);
-        testContract.setOraclePrice(newSpotPrice);
+        (uint256 collateral, uint256 normalDebt) = vault.positions(user);
+        if(collateral == 0 || normalDebt == 0) return;
 
-        address[] memory owners = new address[](1);
-        owners[0] = user;
+        liquidatedPositions = new address[](1);
+        liquidatedPositions[0] = user;
         uint256[] memory repayAmounts = new uint256[](1);
-        if(fullLiquidation){
-            repayAmounts[0] = type(uint256).max;
-        } else {
-            // todo compute a random partial amount to be liquidated
-            repayAmounts[0] = type(uint256).max;
-        }
-        
-        vault.liquidatePositions(owners, repayAmounts);
+        repayAmounts[0] = bound(randomSeed, minLiquidateUserAmount, normalDebt * 2);
 
-        testContract.setOraclePrice(WAD);
+        _liquidatePositions(liquidatedPositions, repayAmounts);
 
         trackCallEnd(msg.sig);
     }
 
-    function liquidateAll() public useCurrentTimestamp() {
+    function liquidateMultiple(uint256 countSeed, uint256 randomSeed) public useCurrentTimestamp {
         trackCallStart(msg.sig);
 
+        if(count(USERS_CATEGORY) == 0) return;
+
+        uint256 count = bound(countSeed, 1, maxCreateUserAmount);
+        liquidatedPositions = new address[](count);
+        uint256[] memory repayAmounts = new uint256[](count);
+
+        for (uint256 i = 0; i<count; ++i) {
+            address user = getRandomActor(USERS_CATEGORY, uint256(keccak256(abi.encode(randomSeed, i))));
+            for (uint256 userIdx = 0; userIdx < i; ++userIdx){
+                if (user == liquidatedPositions[userIdx]) user = address(0);
+            }
+            liquidatedPositions[i] = user;
+
+            (uint256 collateral, uint256 normalDebt) = vault.positions(user);
+            // skip liquidation if the position is empty
+            if (collateral == 0 || normalDebt == 0 || user == address(0)) {
+                repayAmounts[i] = 0;
+            } else {
+                repayAmounts[i] = bound(randomSeed, minLiquidateUserAmount, normalDebt * 2);   
+            }
+        }
+
+        _liquidatePositions(liquidatedPositions, repayAmounts);
         trackCallEnd(msg.sig);
     }
 
-    /// ======== Helper Functions ======== ///
+    /// ======== Value tracking helper functions ======== ///
 
-    function _liquidatePosition(address position, uint256 liquidationHealthFactor, bool isFullLiquidation) private {
-        liquidationHealthFactor = bound(liquidationHealthFactor, 0, liquidationRatio - 1);
-        uint256 newSpotPrice = liquidationPrice(vault);
+    function getPositionHealth(
+        address position
+    ) public view returns (uint256 prevHealth, uint256 currentHealth) {
+        (bytes32 prevHealthBytes, bytes32 currentHealthBytes) = getTrackedValue(keccak256(abi.encodePacked("positionHealth", position)));
+        return (uint256(prevHealthBytes), uint256(currentHealthBytes));
+    }
+
+    function getPositionDebt(
+        address position
+    ) public view returns (uint256 prevDebt, uint256 currentDebt) {
+        (bytes32 prevDebtBytes, bytes32 currentDebtBytes) = getTrackedValue(keccak256(abi.encodePacked("positionDebt", position)));
+        return (uint256(prevDebtBytes), uint256(currentDebtBytes));
+    }
+
+    function getRepayAmount(address position) public view returns (uint256 amount) {
+        return uint256(getGhostValue(keccak256(abi.encodePacked("repayAmount", position))));
+    }
+
+    function getIsSafeLiquidation(address position) public view returns (bool) {
+        uint256 isSafeFlag = uint256(getGhostValue(keccak256(abi.encodePacked("isSafeLiquidation", position))));
+
+        return isSafeFlag == 1;
+    }
+
+    function _trackPositionHealth(address position, uint256 spot) private returns (uint256 currentHealth){
+        (uint256 collateral, uint256 normalDebt) = vault.positions(position);
+        (uint64 rateAccumulator,, uint256 accruedRebate) = vault.virtualIRS(position);
+
+        uint256 debt = calculateDebt(normalDebt, rateAccumulator, accruedRebate);
+        if (collateral == 0 || normalDebt == 0) {
+            currentHealth = type(uint256).max;
+        } else {
+            currentHealth = wdiv(wdiv(wmul(collateral, spot), debt), liquidationRatio);
+        }
+        trackValue(keccak256(abi.encodePacked("positionHealth", position)), bytes32(currentHealth));
+    }
+
+    function _trackPositionDebt(address position) private returns (uint256 debt) {
+        ( , uint256 normalDebt) = vault.positions(position);
+
+        (uint64 rateAccumulator, uint256 accruedRebate, ) = vault.virtualIRS(position);
+        debt = calculateDebt(normalDebt, rateAccumulator, accruedRebate);
+
+        trackValue(keccak256(abi.encodePacked("positionDebt", position)), bytes32(debt));
+    }
+
+    function _setRepayAmount(address position, uint256 repayAmount) private {
+        setGhostValue(keccak256(abi.encodePacked("repayAmount", position)), bytes32(repayAmount));
+    }
+
+    function _setIsSafeLiquidation(address position, uint256 isSafe) private {
+        setGhostValue(keccak256(abi.encodePacked("isSafeLiquidation", position)), bytes32(isSafe));
+    }
+
+    /// ======== Liquidation helper functions ======== ///
+
+    function _liquidatePositions(
+        address[] memory positions, uint256[] memory repayAmounts
+    ) private {
+
+        uint256 newSpotPrice =  _getLiquidationPrice(positions);
         testContract.setOraclePrice(newSpotPrice);
 
-        address[] memory owners = new address[](1);
-        owners[0] = position;
-        uint256[] memory repayAmounts = new uint256[](1);
-        if(isFullLiquidation){
-            repayAmounts[0] = type(uint256).max;
-        } else {
-            // todo compute a random partial amount to be liquidated
-            repayAmounts[0] = type(uint256).max;
-        }
-        
-        vault.liquidatePositions(owners, repayAmounts);
+        preLiquidationDebt = 0;
+        postLiquidationDebt = 0;
+        // track the debt and health of the positions pre liquidation
+        uint256 len = positions.length;
+        for (uint256 i=0; i<len; ++i) {
+            // skip if the position was not liquidated
+            if(repayAmounts[i] == 0) continue;
 
+            uint256 debt = _trackPositionDebt(positions[i]);
+            preLiquidationDebt += debt;
+            (uint256 collateral, ) = vault.positions(positions[i]);
+            uint256 collateralValue = wmul(wmul(collateral, newSpotPrice), liquidationDiscount);
+            _trackPositionHealth(positions[i], newSpotPrice);
+            _setIsSafeLiquidation(positions[i], (collateralValue  >= debt) ? 1 : 0);
+            _setRepayAmount(positions[i], repayAmounts[i]);
+        }
+
+        (int256 balance, ) = cdm.accounts(address(this));
+        (int256 bufferBalance, ) = cdm.accounts(buffer);
+        uint256 bufferInitialDebt = getDebt(bufferBalance);
+
+        vault.liquidatePositions(positions, repayAmounts);
+        
+        (int256 finalBalance, ) = cdm.accounts(address(this));
+        (bufferBalance, ) = cdm.accounts(buffer);
+        uint256 bufferFinalDebt = getDebt(bufferBalance);
+
+        // track the debt and health of the positions post liquidation
+        for (uint256 i=0; i<len; ++i) {
+            // skip if the position was not liquidated
+            if(repayAmounts[i] == 0) continue;
+            
+            postLiquidationDebt += _trackPositionDebt(positions[i]);
+            _trackPositionHealth(positions[i], newSpotPrice);
+        }
+
+        creditPaid = uint256(balance - finalBalance);
+        accruedBadDebt = bufferFinalDebt - bufferInitialDebt;
+        
         testContract.setOraclePrice(WAD);
+    }
+
+    function _getLiquidationPrice(
+        address[] memory positions
+    ) private view returns (uint256 liquidationPrice_) {
+        liquidationPrice_ = type(uint256).max;
+        uint256 len = positions.length;
+        for (uint256 i=0; i<len; ++i) {
+            (uint256 collateral, uint256 normalDebt) = vault.positions(positions[i]);
+            if (collateral == 0 || normalDebt == 0) continue;
+            uint256 currentLiqPrice = liquidationPrice(collateral, normalDebt);
+            if(liquidationPrice_ > currentLiqPrice) {
+                liquidationPrice_ = currentLiqPrice;
+            }
+        }
+
+        if (liquidationPrice_ == type(uint256).max) {
+            liquidationPrice_ = 0;
+        }
+
+        return wmul(liquidationPrice_, uint256(0.9 ether));
     }
 }

--- a/src/utils/Math.sol
+++ b/src/utils/Math.sol
@@ -101,6 +101,22 @@ function wmul(uint256 x, int256 y) pure returns (int256 z) {
     }
 }
 
+/// @dev Equivalent to `(x * y) / WAD` rounded up.
+/// @dev Taken from https://github.com/Vectorized/solady/blob/969a78905274b32cdb7907398c443f7ea212e4f4/src/utils/FixedPointMathLib.sol#L69C22-L69C22
+function wmulUp(uint256 x, uint256 y) pure returns (uint256 z) {
+    /// @solidity memory-safe-assembly
+    assembly {
+        // Equivalent to `require(y == 0 || x <= type(uint256).max / y)`.
+        if mul(y, gt(x, div(not(0), y))) {
+            // Store the function selector of `Math__mul_overflow()`.
+            mstore(0x00, 0xc4c5d7f5)
+            // Revert with (offset, size).
+            revert(0x1c, 0x04)
+        }
+        z := add(iszero(iszero(mod(mul(x, y), WAD))), div(mul(x, y), WAD))
+    }
+}
+
 /// @dev Equivalent to `(x * WAD) / y` rounded down.
 /// @dev Taken from https://github.com/Vectorized/solady/blob/6d706e05ef43cbed234c648f83c55f3a4bb0a520/src/utils/FixedPointMathLib.sol#L84
 function wdiv(uint256 x, uint256 y) pure returns (uint256 z) {
@@ -115,6 +131,22 @@ function wdiv(uint256 x, uint256 y) pure returns (uint256 z) {
             revert(0x1c, 0x04)
         }
         z := div(mul(x, WAD), y)
+    }
+}
+
+/// @dev Equivalent to `(x * WAD) / y` rounded up.
+/// @dev Taken from https://github.com/Vectorized/solady/blob/969a78905274b32cdb7907398c443f7ea212e4f4/src/utils/FixedPointMathLib.sol#L99
+function wdivUp(uint256 x, uint256 y) pure returns (uint256 z) {
+    /// @solidity memory-safe-assembly
+    assembly {
+        // Equivalent to `require(y != 0 && (WAD == 0 || x <= type(uint256).max / WAD))`.
+        if iszero(mul(y, iszero(mul(WAD, gt(x, div(not(0), WAD)))))) {
+            // Store the function selector of `DivWadFailed()`.
+            mstore(0x00, 0xbcbede65)
+            // Revert with (offset, size).
+            revert(0x1c, 0x04)
+        }
+        z := add(iszero(iszero(mod(mul(x, WAD), y))), div(mul(x, WAD), y))
     }
 }
 

--- a/src/utils/Math.sol
+++ b/src/utils/Math.sol
@@ -141,7 +141,7 @@ function wdivUp(uint256 x, uint256 y) pure returns (uint256 z) {
     assembly {
         // Equivalent to `require(y != 0 && (WAD == 0 || x <= type(uint256).max / WAD))`.
         if iszero(mul(y, iszero(mul(WAD, gt(x, div(not(0), WAD)))))) {
-            // Store the function selector of `DivWadFailed()`.
+            // Store the function selector of `Math__div_overflow()`.
             mstore(0x00, 0xbcbede65)
             // Revert with (offset, size).
             revert(0x1c, 0x04)


### PR DESCRIPTION
- Fixed liquidation flow if bad debt is accumulated during full liquidations, previously the position update flow would always revert due to the debt floor check.
- Fixed debt floor reverts due to precision loss.
- Added support for rounded-up mul and div.
- Added liquidation invariants.
